### PR TITLE
Fix bugs of the openssl-related on the abyss server in the advanced edition

### DIFF
--- a/advanced/GNUmakefile
+++ b/advanced/GNUmakefile
@@ -117,6 +117,7 @@ shell_config: $(BLDDIR)/config.mk
 	@echo 'FEATURE_LIST="$(FEATURE_LIST)"'				>>$@
 	@echo 'PREFIX="$(PREFIX)"'					>>$@
 	@echo 'HEADERINST_DIR="$(HEADERINST_DIR)"'                      >>$@
+	@echo 'PROGRAMINST_DIR="$(PROGRAMINST_DIR)"'                    >>$@
 	@echo 'LIBINST_DIR="$(LIBINST_DIR)"'                            >>$@
 	@echo 'BLDDIR="$(BLDDIR)"'                                      >>$@
 	@echo 'ABS_SRCDIR="$(ABS_SRCDIR)"'                              >>$@
@@ -162,6 +163,7 @@ distdir: distdir-common
 install: $(DEFAULT_SUBDIRS:%=%/install) install-common
 
 HEADERDESTDIR = $(DESTDIR)$(HEADERINST_DIR)
+PGROGRAMDESTDIR = $(DESTDIR)$(PROGRAMINST_DIR)
 
 .PHONY: uninstall
 uninstall: $(DEFAULT_SUBDIRS:%=%/uninstall) uninstall-common

--- a/advanced/include/Makefile
+++ b/advanced/include/Makefile
@@ -128,8 +128,11 @@ ifeq ($(ENABLE_CGI_SERVER),yes)
   COMPAT_LINK_CMDS += $(LN_S) xmlrpc-c/server_cgi.h xmlrpc_cgi.h;
 endif
 
-ifeq ($(HAVE_OPENSSL),Y)
-  HEADERS_TO_INSTALL += xmlrpc-c/openssl_thread.h
+ifeq ($(HAVE_OPENSSL),yes)
+  HEADERS_TO_INSTALL += \
+    xmlrpc-c/openssl_thread.h \
+    xmlrpc-c/abyss_openssl.h \
+
 endif
 
 default: all

--- a/advanced/lib/abyss/src/socket_openssl.c
+++ b/advanced/lib/abyss/src/socket_openssl.c
@@ -257,6 +257,8 @@ channelDestroy(TChannel * const channelP) {
     if (!channelOpenSslP->userSuppliedSsl)
         SSL_shutdown(channelOpenSslP->sslP);
 
+    close(channelOpenSslP->fd);
+
     free(channelOpenSslP);
 }
 
@@ -481,6 +483,7 @@ makeChannelFromSsl(SSL *         const sslP,
         
         channelOpenSslP->sslP = sslP;
         channelOpenSslP->userSuppliedSsl = userSuppliedSsl;
+        channelOpenSslP->fd = SSL_get_fd(sslP);
         
         /* This should be ok as far as I can tell */
         ChannelCreate(&channelVtbl, channelOpenSslP, &channelP);

--- a/advanced/lib/abyss/src/socket_openssl.c
+++ b/advanced/lib/abyss/src/socket_openssl.c
@@ -639,44 +639,32 @@ createChannelFromAcceptedConn(int             const acceptedFd,
                               void **         const channelInfoPP,
                               const char **   const errorP) {
 
-    struct ChannelOpenSsl * channelOpenSslP;
+    SSL * sslP;
+    const char * error;
 
-    MALLOCVAR(channelOpenSslP);
-
-    if (!channelOpenSslP)
-        xmlrpc_asprintf(errorP, "Unable to allocate memory");
-    else {
-        SSL * sslP;
-        const char * error;
-
-        createSslFromAcceptedConn(acceptedFd, sslCtxP, &sslP, &error);
+    createSslFromAcceptedConn(acceptedFd, sslCtxP, &sslP, &error);
         
-        if (error) {
-            xmlrpc_asprintf(errorP, "Failed to create an OpenSSL connection "
-                            "from the accepted TCP connection.  %s", error);
-            xmlrpc_strfree(error);
-        } else {
-            struct abyss_openSsl_chaninfo * channelInfoP;
+    if (error) {
+        xmlrpc_asprintf(errorP, "Failed to create an OpenSSL connection "
+                        "from the accepted TCP connection.  %s", error);
+        xmlrpc_strfree(error);
+    } else {
+        struct abyss_openSsl_chaninfo * channelInfoP;
 
-            makeChannelInfo(&channelInfoP, sslP, errorP);
-            if (!*errorP) {
-                bool const userSuppliedFalse = false;
+        makeChannelInfo(&channelInfoP, sslP, errorP);
+        if (!*errorP) {
+            bool const userSuppliedFalse = false;
 
-                makeChannelFromSsl(sslP, userSuppliedFalse,
-                                   channelPP, errorP);
+            makeChannelFromSsl(sslP, userSuppliedFalse,
+                               channelPP, errorP);
 
-                if (*errorP)
-                    free(channelInfoP);
-                else
-                    *channelInfoPP = channelInfoP;
-            }
             if (*errorP)
-                SSL_free(sslP);
+                free(channelInfoP);
             else
-                channelOpenSslP->sslP = sslP;
+                *channelInfoPP = channelInfoP;
         }
         if (*errorP)
-            free(channelOpenSslP);
+            SSL_free(sslP);
     }
 }
 

--- a/advanced/lib/abyss/src/socket_openssl.c
+++ b/advanced/lib/abyss/src/socket_openssl.c
@@ -254,9 +254,10 @@ channelDestroy(TChannel * const channelP) {
 
     struct ChannelOpenSsl * const channelOpenSslP = channelP->implP;
 
-    if (!channelOpenSslP->userSuppliedSsl)
+    if (!channelOpenSslP->userSuppliedSsl){
         SSL_shutdown(channelOpenSslP->sslP);
-
+        SSL_free(channelOpenSslP->sslP);
+    }
     close(channelOpenSslP->fd);
 
     free(channelOpenSslP);


### PR DESCRIPTION
I am using the xmlrpc-c library for the openssl of the abyss server in the advanced edition.
But some glitches occurred in using the library.
So I have fixed them.
Could you please check and pull it.  